### PR TITLE
Update meta-git-clone

### DIFF
--- a/bin/meta-git-clone
+++ b/bin/meta-git-clone
@@ -15,11 +15,15 @@ const repoUrl = process.argv[2] === 'blank' ?
                       process.argv[3] :
                       process.argv[2];
 
-const dirname = path.basename(repoUrl).replace('.git', '');
+const dirNameIndex=process.argv.indexOf('--dir');
+const dirname =dirNameIndex!==0?process.argv[dirNameIndex+1]:path.basename(repoUrl).replace('.git', '');
+
+const branchNameIndex=process.argv.indexOf('--branch');
+const branch=branchNameIndex!==0?process.argv[branchNameIndex+1]:null;
 
 console.log(`meta git cloning into \'${repoUrl}\' at ${dirname}`);
-
-exec({ cmd: `git clone ${repoUrl} ${dirname}`, displayDir: dirname }, (err, result) => {
+const mainCmd=branch===null?`git clone ${repoUrl} ${dirname}`: `git clone --single-branch -b ${branch} ${repoUrl} ${dirname}`;
+exec({ cmd: mainCmd , displayDir: dirname}, (err, result) => {
   if (err) throw err;
 
   const newDir = path.resolve(dirname);
@@ -43,8 +47,9 @@ exec({ cmd: `git clone ${repoUrl} ${dirname}`, displayDir: dirname }, (err, resu
     folder = folders.pop()
 
     const gitUrl = projects[folder];
+	const cmd=branch===null?`git clone ${gitUrl} ${folder}`: `git clone --single-branch -b ${branch} ${gitUrl} ${folder}`;
 
-    exec({ cmd: `git clone ${gitUrl} ${folder}`, displayDir: path.join(newDir, folder) },  (err) => {
+    exec({ cmd: cmd, displayDir: path.join(newDir, folder) },  (err) => {
       if (err) throw err;
 
       child();


### PR DESCRIPTION
Added additional optional parameters for meta git clone:

1. --branch: cloning specific branch, run the git with "--single-branch -b ${branch}"
2. --dir: folder to check out the main repo, folder names for child repos picked up from the .meta project file
example:
meta git clone "https://github.com/mateodelnorte/meta.git" --branch develop --dir .
Parameters are recognized with "process.argv.indexOf('--paramname')"